### PR TITLE
feat: add support to bookmark mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.4 - 2025-5-4
+
+Adding support to bookmark mocks without `.set`
+
+
 # 1.0.3 - 2025-5-4
 
 Minor adjusts to enable the http intercept

--- a/packages/lib/CHANGELOG.md
+++ b/packages/lib/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.4 - 2025-5-4
+
+Adding support to bookmark mocks without `.set`
+
+
 # 1.0.3 - 2025-5-4
 
 Minor adjusts to enable the http intercept

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omariosouto/common-http-client",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "main": "src/index.js",
   "scripts": {

--- a/packages/lib/src/index/index.test.ts
+++ b/packages/lib/src/index/index.test.ts
@@ -76,7 +76,6 @@ describe("HttpClient for Query Usage", () => {
       // 2. Validate the response
       expect(bookmarkResponse.body).toEqual(payloadMock);
       expect(bookmarkResponse.status).toEqual(200);
-
     });
 
     describe("AND this http call has custom url parameters", () => {

--- a/packages/lib/src/index/index.test.ts
+++ b/packages/lib/src/index/index.test.ts
@@ -40,7 +40,7 @@ const bookmarks: HttpClientBookmarks = {
 
 describe("HttpClient for Query Usage", () => {
   describe("WHEN making a query HTTP call", () => {
-    it("RETURNs the content as expected", async () => {
+    it.only("RETURNs the content as expected", async () => {
       // 0. Set the mock
       httpClientMock.on("GET", "https://site.com/api").reply(200, {
         content: "mocked data",
@@ -55,13 +55,35 @@ describe("HttpClient for Query Usage", () => {
       // 2. Validate the response
       expect(response.body).toEqual({ content: "mocked data" });
       expect(response.status).toEqual(200);
+
+      // ================================================================
+      // [Bookmarks usage]
+      // ================================================================
+      
+      // 0. Set the mock
+      const payloadMock = schemaGenerate(DemoWireInSchema);
+      httpClientMock
+        .on("GET", "demo-request", { bookmarks })
+        .reply(200, payloadMock);
+
+      // 1. Trigger the request
+      const bookmarkResponse = await HttpClient.request({
+        url: "demo-request",
+        method: "GET",
+        bookmarks,
+      });
+
+      // 2. Validate the response
+      expect(bookmarkResponse.body).toEqual(payloadMock);
+      expect(bookmarkResponse.status).toEqual(200);
+
     });
 
     describe("AND this http call has custom url parameters", () => {
       it("RETURNs the content as expected", async () => {
         const params = { param1: "1", param2: (2).toString() };
         // 0. Set the mock
-        httpClientMock.on("GET", "https://site.com/api/users/:param1/group/:param2", params).reply(200, {
+        httpClientMock.on("GET", "https://site.com/api/users/:param1/group/:param2", { params }).reply(200, {
           content: "mocked data with params",
         });
 
@@ -137,7 +159,8 @@ describe("HttpClient for Query Usage", () => {
       });
     });
   });
-  describe("WHEN making a query HTTP call through bookmarks", () => {
+
+  describe("WHEN making a query HTTP call through bookmarks `.set()`", () => {
     it("RETURNs the content as expected", async () => {
       // 0. Set the mock
       const payloadMock = schemaGenerate(DemoWireInSchema);
@@ -332,7 +355,7 @@ describe("HttpClient for Mutation Usage", () => {
             body: { invalidBody: 1 },
             bookmarks,
           })
-        // 2. Validate the response, given that the body didn't match the schema
+          // 2. Validate the response, given that the body didn't match the schema
         ).rejects.toThrowError();
 
         await HttpClient.request({
@@ -341,9 +364,9 @@ describe("HttpClient for Mutation Usage", () => {
           body: { invalidBody: 1 },
           bookmarks,
         })
-        .catch((error) => {
-          expect(error).toBeInstanceOf(SchemaError);
-        });
+          .catch((error) => {
+            expect(error).toBeInstanceOf(SchemaError);
+          });
       });
     });
   });

--- a/packages/lib/src/index/index.test.ts
+++ b/packages/lib/src/index/index.test.ts
@@ -40,7 +40,7 @@ const bookmarks: HttpClientBookmarks = {
 
 describe("HttpClient for Query Usage", () => {
   describe("WHEN making a query HTTP call", () => {
-    it.only("RETURNs the content as expected", async () => {
+    it("RETURNs the content as expected", async () => {
       // 0. Set the mock
       httpClientMock.on("GET", "https://site.com/api").reply(200, {
         content: "mocked data",


### PR DESCRIPTION
## Lib Management

| Commands to manage version bumps |
| --- |
| bumper/release |
| bumper/beta    |
| bumper/skip    |

## Changelog

Adding support to bookmark mocks without `.set`
